### PR TITLE
std::list::size() is const, so ProtoSignal::size() should also be const.

### DIFF
--- a/SimpleSignal.h
+++ b/SimpleSignal.h
@@ -125,7 +125,7 @@ public:
   }
   // Number of connected slots.
   std::size_t
-  size ()
+  size () const
   {
     return callback_list_.size();
   }


### PR DESCRIPTION
Omitting const qualifier causes the following cppcheck warning:

Assert statement calls a function which may have desired side effects: 'size'.